### PR TITLE
some build update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,7 +317,7 @@ dnl of EXT plugins
 AM_CONDITIONAL(USE_ROCKCHIPMPP, false)
 AM_CONDITIONAL(USE_VPUDEC, false)
 AM_CONDITIONAL(USE_KMS, false)
-AM_CONDITIONAL(USE_DRMROCKCHIP, false)
+AM_CONDITIONAL(USE_RKXIMAGE, false)
 
 dnl *** finalize CFLAGS, LDFLAGS, LIBS
 
@@ -397,11 +397,9 @@ AG_GST_CHECK_FEATURE(VPUDEC, [rockchip vpu legacy libraries], vpudec, [
     HAVE_VPUDEC=yes, HAVE_VPUDEC=no)
 ])
 
-translit(dnm, m, l) AM_CONDITIONAL(USE_DRMROCKCHIP, true)
-AG_GST_CHECK_FEATURE(DRMROCKCHIP, [rockchip drm/kms libraries], drmrockchip, [
-  PKG_CHECK_MODULES([X11], [x11], HAVE_X11=yes, HAVE_X11=no)
-  PKG_CHECK_MODULES([DRMROCKCHIP], [libdrm_rockchip],
-    HAVE_DRMROCKCHIP=yes, HAVE_DRMROCKCHIP=no)
+translit(dnm, m, l) AM_CONDITIONAL(USE_RKXIMAGE, true)
+AG_GST_CHECK_FEATURE(RKXIMAGE, [drm/kms and x11 libraries], rkximage, [
+  PKG_CHECK_MODULES([RKXIMAGE], [x11 libdrm], HAVE_RKXIMAGE=yes, HAVE_RKXIMAGE=no)
 ])
 
 dnl keep this alphabetic per directory, please

--- a/gst/Makefile.am
+++ b/gst/Makefile.am
@@ -10,7 +10,7 @@ else
 VPUDEC_DIR=
 endif
 
-if USE_DRMROCKCHIP
+if USE_RKXIMAGE
 RKXIMAGE_DIR=rkximage
 else
 RKXIMAGE_DIR=

--- a/gst/rkximage/Makefile.am
+++ b/gst/rkximage/Makefile.am
@@ -6,9 +6,7 @@ libgstrkximage_la_SOURCES =			\
 	$(NULL)
 
 libgstrkximage_la_CFLAGS =				\
-	$(X11_CFLAGS)				\
-	$(DRMROCKCHIP_CFLAGS)			\
-	$(KMS_DRM_CFLAGS) 			\
+	$(RKXIMAGE_CFLAGS)				\
 	$(GST_PLUGINS_BASE_CFLAGS)		\
 	$(GST_BASE_CFLAGS)			\
 	$(GST_VIDEO_CFLAGS)			\
@@ -17,9 +15,7 @@ libgstrkximage_la_CFLAGS =				\
 	$(NULL)
 
 libgstrkximage_la_LIBADD =				\
-	$(X11_LIBS)				\
-	$(DRMROCKCHIP_LIBS)			\
-	$(KMS_DRM_LIBS) 			\
+	$(RKXIMAGE_LIBS)				\
 	$(GST_PLUGINS_BASE_LIBS)		\
 	$(GST_BASE_LIBS)			\
 	$(GST_VIDEO_LIBS)                       \


### PR DESCRIPTION
we might have another drm sink for none-x11 use, so correct the name of x11 drm sink.

