### PR TITLE
rockchipmpp: Add mppvpxalphadecodebin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,9 @@ AG_GST_CHECK_MODULES([GST_ALLOCATORS],
 AG_GST_CHECK_MODULES([GST_VIDEO],
   [gstreamer-video-$GST_API_VERSION], [$GSTPB_REQ], yes)
 
+AG_GST_CHECK_MODULES([GST_PBUTILS],
+  [gstreamer-pbutils-$GST_API_VERSION], [$GSTPB_REQ], yes)
+
 GST_TOOLS_DIR=`$PKG_CONFIG --variable=toolsdir gstreamer-$GST_API_VERSION`
 if test -z $GST_TOOLS_DIR; then
   AC_MSG_ERROR([no tools dir defined in GStreamer pkg-config file; core upgrade needed.])

--- a/gst/rockchipmpp/Makefile.am
+++ b/gst/rockchipmpp/Makefile.am
@@ -10,6 +10,8 @@ libgstrockchipmpp_la_SOURCES =			\
 	gstmppjpegdec.c				\
 	gstmpp.c				\
 	gstmppdec.c				\
+	gstmppalphadecodebin.c			\
+	gstmppvpxalphadecodebin.c		\
 	$(NULL)
 
 libgstrockchipmpp_la_CFLAGS =			\
@@ -18,6 +20,7 @@ libgstrockchipmpp_la_CFLAGS =			\
 	$(GST_PLUGINS_BASE_CFLAGS)		\
 	$(GST_ALLOCATORS_CFLAGS)		\
 	$(GST_VIDEO_CFLAGS)			\
+	$(GST_PBUTILS_CFLAGS)			\
 	$(ROCKCHIP_MPP_CFLAGS)			\
 	$(RGA_CFLAGS)				\
 	$(NULL)
@@ -27,6 +30,7 @@ libgstrockchipmpp_la_LIBADD =			\
 	$(GST_BASE_LIBS)			\
 	$(GST_PLUGINS_BASE_LIBS)		\
 	$(GST_VIDEO_LIBS)			\
+	$(GST_PBUTILS_LIBS)			\
 	$(GST_ALLOCATORS_LIBS)			\
 	$(ROCKCHIP_MPP_LIBS)			\
 	$(RGA_LIBS)				\
@@ -48,4 +52,6 @@ noinst_HEADERS =				\
 	gstmppallocator.h			\
 	gstmppvideodec.h			\
 	gstmppdec.h				\
+	gstmppalphadecodebin.h			\
+	gstmppvpxalphadecodebin.h		\
 	$(NULL)

--- a/gst/rockchipmpp/gstmpp.c
+++ b/gst/rockchipmpp/gstmpp.c
@@ -35,6 +35,7 @@
 #include "gstmppjpegenc.h"
 #include "gstmppjpegdec.h"
 #include "gstmppvideodec.h"
+#include "gstmppvpxalphadecodebin.h"
 
 GST_DEBUG_CATEGORY_STATIC (mpp_debug);
 #define GST_CAT_DEFAULT mpp_debug
@@ -397,6 +398,11 @@ plugin_init (GstPlugin * plugin)
 
   if (!gst_element_register (plugin, "mppjpegdec", GST_RANK_PRIMARY + 1,
           gst_mpp_jpeg_dec_get_type ()))
+    return FALSE;
+
+  if (!gst_element_register (plugin, "mppvpxalphadecodebin",
+          GST_RANK_PRIMARY + GST_MPP_ALPHA_DECODE_BIN_RANK_OFFSET,
+          gst_mpp_vpx_alpha_decode_bin_get_type ()))
     return FALSE;
 
   return TRUE;

--- a/gst/rockchipmpp/gstmppalphadecodebin.c
+++ b/gst/rockchipmpp/gstmppalphadecodebin.c
@@ -1,0 +1,215 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gst/pbutils/pbutils.h>
+
+#include "gstmppalphadecodebin.h"
+
+GST_DEBUG_CATEGORY_STATIC (mppalphadecodebin_debug);
+#define GST_CAT_DEFAULT (mppalphadecodebin_debug)
+
+typedef struct
+{
+  GstBin parent;
+
+  gboolean constructed;
+  const gchar *missing_element;
+} GstMppAlphaDecodeBinPrivate;
+
+#define gst_mpp_alpha_decode_bin_parent_class parent_class
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (GstMppAlphaDecodeBin,
+    gst_mpp_alpha_decode_bin, GST_TYPE_BIN,
+    G_ADD_PRIVATE (GstMppAlphaDecodeBin);
+    GST_DEBUG_CATEGORY_INIT (mppalphadecodebin_debug, "mppalphadecodebin", 0,
+        "mppalphadecodebin"));
+
+static GstStaticPadTemplate gst_mpp_alpha_decode_bin_src_template =
+GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("ANY")
+    );
+
+static gboolean
+gst_mpp_alpha_decode_bin_open (GstMppAlphaDecodeBin * self)
+{
+  GstMppAlphaDecodeBinPrivate *priv =
+      gst_mpp_alpha_decode_bin_get_instance_private (self);
+
+  if (priv->missing_element) {
+    gst_element_post_message (GST_ELEMENT (self),
+        gst_missing_element_message_new (GST_ELEMENT (self),
+            priv->missing_element));
+  } else if (!priv->constructed) {
+    GST_ELEMENT_ERROR (self, CORE, FAILED,
+        ("Failed to construct mpp alpha decoder pipeline."), (NULL));
+  }
+
+  return priv->constructed;
+}
+
+static GstStateChangeReturn
+gst_mpp_alpha_decode_bin_change_state (GstElement * element,
+    GstStateChange transition)
+{
+  GstMppAlphaDecodeBin *self = GST_MPP_ALPHA_DECODE_BIN (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      if (!gst_mpp_alpha_decode_bin_open (self))
+        return GST_STATE_CHANGE_FAILURE;
+      break;
+    default:
+      break;
+  }
+
+  return GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+}
+
+static void
+gst_mpp_alpha_decode_bin_constructed (GObject * obj)
+{
+  GstMppAlphaDecodeBin *self = GST_MPP_ALPHA_DECODE_BIN (obj);
+  GstMppAlphaDecodeBinPrivate *priv =
+      gst_mpp_alpha_decode_bin_get_instance_private (self);
+  GstMppAlphaDecodeBinClass *klass = GST_MPP_ALPHA_DECODE_BIN_GET_CLASS (self);
+  GstPad *src_gpad, *sink_gpad;
+  GstPad *src_pad = NULL, *sink_pad = NULL;
+  GstElement *alphademux = NULL;
+  GstElement *queue = NULL;
+  GstElement *alpha_queue = NULL;
+  GstElement *decoder = NULL;
+  GstElement *alpha_decoder = NULL;
+  GstElement *alphacombine = NULL;
+
+  /* setup ghost pads */
+  sink_gpad = gst_ghost_pad_new_no_target_from_template ("sink",
+      gst_element_class_get_pad_template (GST_ELEMENT_CLASS (klass), "sink"));
+  gst_element_add_pad (GST_ELEMENT (self), sink_gpad);
+
+  src_gpad = gst_ghost_pad_new_no_target_from_template ("src",
+      gst_element_class_get_pad_template (GST_ELEMENT_CLASS (klass), "src"));
+  gst_element_add_pad (GST_ELEMENT (self), src_gpad);
+
+  /* create elements */
+  alphademux = gst_element_factory_make ("codecalphademux", NULL);
+  if (!alphademux) {
+    priv->missing_element = "codecalphademux";
+    goto cleanup;
+  }
+
+  queue = gst_element_factory_make ("queue", NULL);
+  alpha_queue = gst_element_factory_make ("queue", NULL);
+  if (!queue || !alpha_queue) {
+    priv->missing_element = "queue";
+    goto cleanup;
+  }
+
+  decoder = gst_element_factory_make (klass->decoder_name, "maindec");
+  if (!decoder) {
+    priv->missing_element = klass->decoder_name;
+    goto cleanup;
+  }
+
+  alpha_decoder = gst_element_factory_make (klass->decoder_name, "alphadec");
+  if (!alpha_decoder) {
+    priv->missing_element = klass->decoder_name;
+    goto cleanup;
+  }
+
+  /* We disable QoS on decoders because we need to maintain frame pairing in
+   * order for alphacombine to work. */
+  g_object_set (decoder, "qos", FALSE, NULL);
+  g_object_set (alpha_decoder, "qos", FALSE, NULL);
+
+  alphacombine = gst_element_factory_make ("alphacombine", NULL);
+  if (!alphacombine) {
+    priv->missing_element = "alphacombine";
+    goto cleanup;
+  }
+
+  gst_bin_add_many (GST_BIN (self), alphademux, queue, alpha_queue, decoder,
+      alpha_decoder, alphacombine, NULL);
+
+  /* link elements */
+  sink_pad = gst_element_get_static_pad (alphademux, "sink");
+  gst_ghost_pad_set_target (GST_GHOST_PAD (sink_gpad), sink_pad);
+  gst_clear_object (&sink_pad);
+
+  gst_element_link_pads (alphademux, "src", queue, "sink");
+  gst_element_link_pads (queue, "src", decoder, "sink");
+  gst_element_link_pads (decoder, "src", alphacombine, "sink");
+
+  gst_element_link_pads (alphademux, "alpha", alpha_queue, "sink");
+  gst_element_link_pads (alpha_queue, "src", alpha_decoder, "sink");
+  gst_element_link_pads (alpha_decoder, "src", alphacombine, "alpha");
+
+  src_pad = gst_element_get_static_pad (alphacombine, "src");
+  gst_ghost_pad_set_target (GST_GHOST_PAD (src_gpad), src_pad);
+  gst_object_unref (src_pad);
+
+  g_object_set (queue, "max-size-bytes", 0, "max-size-time", 0,
+      "max-size-buffers", 1, NULL);
+  g_object_set (alpha_queue, "max-size-bytes", 0, "max-size-time", 0,
+      "max-size-buffers", 1, NULL);
+
+  /* signal success, we will handle this in NULL->READY transition */
+  priv->constructed = TRUE;
+  return;
+
+cleanup:
+  gst_clear_object (&alphademux);
+  gst_clear_object (&queue);
+  gst_clear_object (&alpha_queue);
+  gst_clear_object (&decoder);
+  gst_clear_object (&alpha_decoder);
+  gst_clear_object (&alphacombine);
+
+  G_OBJECT_CLASS (parent_class)->constructed (obj);
+}
+
+static void
+gst_mpp_alpha_decode_bin_class_init (GstMppAlphaDecodeBinClass * klass)
+{
+  GstElementClass *element_class = (GstElementClass *) klass;
+  GObjectClass *obj_class = (GObjectClass *) klass;
+
+  /* This is needed to access the subclass class instance, otherwise we cannot
+   * read the class parameters */
+  obj_class->constructed = gst_mpp_alpha_decode_bin_constructed;
+
+  gst_element_class_add_static_pad_template (element_class,
+      &gst_mpp_alpha_decode_bin_src_template);
+  element_class->change_state =
+      GST_DEBUG_FUNCPTR (gst_mpp_alpha_decode_bin_change_state);
+
+  /* let's make the doc generator happy */
+  gst_type_mark_as_plugin_api (GST_TYPE_MPP_ALPHA_DECODE_BIN, 0);
+}
+
+static void
+gst_mpp_alpha_decode_bin_init (GstMppAlphaDecodeBin * self)
+{
+}

--- a/gst/rockchipmpp/gstmppalphadecodebin.h
+++ b/gst/rockchipmpp/gstmppalphadecodebin.h
@@ -1,0 +1,49 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_MPP_ALPHA_DECODE_BIN_H__
+#define __GST_MPP_ALPHA_DECODE_BIN_H__
+
+#include <gst/gst.h>
+
+/* When wrapping, use the original rank plus this offset. The ad-hoc rules is
+ * that hardware implementation will use PRIMARY+1 or +2 to override the
+ * software decoder, so the offset must be large enough to jump over those.
+ * This should also be small enough so that a marginal (64) or secondary
+ * wrapper does not cross the PRIMARY line.
+ */
+#define GST_MPP_ALPHA_DECODE_BIN_RANK_OFFSET 10
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MPP_ALPHA_DECODE_BIN (gst_mpp_alpha_decode_bin_get_type())
+G_DECLARE_DERIVABLE_TYPE (GstMppAlphaDecodeBin,
+    gst_mpp_alpha_decode_bin, GST, MPP_ALPHA_DECODE_BIN, GstBin);
+
+struct _GstMppAlphaDecodeBinClass
+{
+  GstBinClass parent_class;
+
+  const gchar *decoder_name;
+};
+
+G_END_DECLS
+#endif

--- a/gst/rockchipmpp/gstmppvpxalphadecodebin.c
+++ b/gst/rockchipmpp/gstmppvpxalphadecodebin.c
@@ -1,0 +1,70 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:element-mppvpxalphadecodebin
+ * @title: Wrapper to decode MPP VP8/VP9 alpha using mppvideodec
+ *
+ * Use two `mppvideodec` instance in order to decode VP8/VP9 alpha channel.
+ *
+ * Since: 1.20
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gstmppvpxalphadecodebin.h"
+
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("video/x-vp8, codec-alpha = (boolean) true; "
+        "video/x-vp9, codec-alpha = (boolean) true"));
+
+struct _GstMppVpxAlphaDecodeBin
+{
+  GstMppAlphaDecodeBin parent;
+};
+
+#define gst_mpp_vpx_alpha_decode_bin_parent_class parent_class
+G_DEFINE_TYPE (GstMppVpxAlphaDecodeBin, gst_mpp_vpx_alpha_decode_bin,
+    GST_TYPE_MPP_ALPHA_DECODE_BIN);
+
+static void
+gst_mpp_vpx_alpha_decode_bin_class_init (GstMppVpxAlphaDecodeBinClass * klass)
+{
+  GstMppAlphaDecodeBinClass *adbin_class = (GstMppAlphaDecodeBinClass *) klass;
+  GstElementClass *element_class = (GstElementClass *) klass;
+
+  adbin_class->decoder_name = "mppvideodec";
+  gst_element_class_add_static_pad_template (element_class, &sink_template);
+
+  gst_element_class_set_static_metadata (element_class,
+      "VP8/VP9 Alpha Decoder", "Codec/Decoder/Video",
+      "Wrapper bin to decode VP8/VP9 with alpha stream.",
+      "Julian Bouzas <julian.bouzas@collabora.com>");
+}
+
+static void
+gst_mpp_vpx_alpha_decode_bin_init (GstMppVpxAlphaDecodeBin * self)
+{
+}

--- a/gst/rockchipmpp/gstmppvpxalphadecodebin.h
+++ b/gst/rockchipmpp/gstmppvpxalphadecodebin.h
@@ -1,0 +1,36 @@
+/* GStreamer
+ * Copyright (C) <2021> Collabora Ltd.
+ *   Author: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+ *   Author: Julian Bouzas <julian.bouzas@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_MPP_VPX_ALPHA_DECODE_BIN_H__
+#define __GST_MPP_VPX_ALPHA_DECODE_BIN_H__
+
+#include "gstmppalphadecodebin.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_MPP_VPX_ALPHA_DECODE_BIN (gst_mpp_vpx_alpha_decode_bin_get_type())
+G_DECLARE_FINAL_TYPE (GstMppVpxAlphaDecodeBin,
+    gst_mpp_vpx_alpha_decode_bin, GST, MPP_VPX_ALPHA_DECODE_BIN, GstMppAlphaDecodeBin);
+
+GST_ELEMENT_REGISTER_DECLARE (mpp_vpx_alpha_decode_bin);
+
+G_END_DECLS
+#endif


### PR DESCRIPTION
Similar to gst-plugins-bad's [codecalpha](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/codecalpha), this PR adds a new `mppvpxalphadecodebin` element that wraps the existing `mppvideodec` decoder to allow decoding the alpha channel of VP8 and VP9 formats.